### PR TITLE
docs(glhf): enrich README with what-it-does, pipeline role, building-blocks reference, observability, and a handler-lifecycle deep-dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,61 @@
 
 Code Lambda for fun and profit.
 
-## Description
+glhf ("Good Lambda Have Function") is a reusable Node.js / ESM library that builds
+AWS Lambda handler factories with minimal boilerplate, wiring up config loading,
+an [Awilix] dependency-injection container, structured logging, and per-event-source
+parsing, serialization, and error-handling strategies.
 
-This library trivializes creating powerful AWS Lambda handler
-functions with minimal boilerplate.
+## What it does
+
+glhf exports a family of **handler-factory functions**, one per AWS Lambda event
+source. Each is a thin wrapper around a central `createHandler` factory so the same
+engine serves every event type:
+
+- **`invokeHandler`** — raw Lambda invocation / arbitrary JSON events (the default
+  / fallback handler). Identity parser and serializer, single-run event strategy.
+- **`eventbridgeHandler`** — [EventBridge events], with dead-letter-queue redrive
+  support that transparently unwraps both EventBridge-origin and Lambda-`onFailure`
+  DLQ records.
+- **`sqsHandler`** / **`sqsJsonHandler`** — SQS batches, processed **per record in
+  parallel**, each in its own Awilix child scope. The JSON variant also parses each
+  message body as JSON.
+- **`httpHandler`** / **`httpJsonHandler`** — API Gateway HTTP API v2 proxy events,
+  with [Boom]-based mapping of processor errors to HTTP status codes. The JSON
+  variant parses the request body and serializes the response body to JSON.
+
+Every handler follows the same lifecycle. On cold start it creates a cache
+([cache-manager], 60s TTL) and an Awilix container; per invocation it builds a
+request context (`ctx`), derives a request id, creates a child structured logger,
+loads configuration via [AWS Config Executor], registers the caller's dependencies,
+creates a scoped container, and runs the chosen **strategy** through a **wrapper**
+that parses the event, invokes the caller's processor, logs start/data/end, and
+serializes the result.
+
+The design deliberately separates four pluggable concerns — **parser**,
+**serializer**, **wrapper**, and **strategy** — so the same core factory powers
+every event source. See [Handler lifecycle and DI scoping](./docs/handler-lifecycle.md)
+for the full flow and the parent-vs-per-event-vs-per-record scoping model.
+
+## Pipeline role
+
+glhf is a foundational **shared library** (published to npm as `@pureskillgg/glhf`),
+not a pipeline stage itself. Virtually every Node.js Lambda across the PureSkill.gg
+CS2 pipeline imports it to create its `handler` export — for example `csgo-mutator`,
+`csgo-profile`, `oauthjs`, automatch and link services, AppSync resolvers, and
+EventBridge / SQS / HTTP consumers.
+
+It sits alongside the other internal libraries it composes: it loads config with
+[`@pureskillgg/ace`][AWS Config Executor] (SSM / env descriptors), logs with
+`@pureskillgg/mlabs-logger`, and uses functional utilities from `@pureskillgg/phi`.
+glhf standardizes how all of these services parse events, load config, log, and
+handle errors so each consuming repo only writes its own `parameters`,
+`registerDependencies`, and `createProcessor`.
+
+This library has **no production AWS infrastructure of its own**. The `serverless.yml`,
+`serverless/*.yml`, and `handlers/` in this repo exist only as a red/blue
+**example / integration-test deployment** used to exercise the library end to end
+(see [Example deployment](#example-deployment-redblue)).
 
 This creates a handler that invokes another AWS Lambda function:
 
@@ -273,6 +324,110 @@ It may optionally call the logger, parser, and serializer.
 A strategy has access to the Awilix container scoped to the event.
 It should resolve and call the processor and optionally handle errors.
 
+## Building blocks
+
+Every handler factory is composed from the same internal primitives. These are the
+real exported names confirmed in [`lib`](./lib); consuming services usually only need
+the handler factories, but the pieces are exported for advanced use and custom handlers.
+
+### Handler factories (`lib/handlers`)
+
+| Export | Source | Role |
+| --- | --- | --- |
+| `invokeHandler` | `lib/handlers/invoke.js` | Raw invocation / generic JSON; identity parser + serializer, event strategy |
+| `eventbridgeHandler` | `lib/handlers/eventbridge.js` | EventBridge events; eventbridge parser + parallel strategy; DLQ redrive |
+| `sqsHandler` / `sqsJsonHandler` | `lib/handlers/sqs.js` | SQS batches; per-record parallel processing in child scopes |
+| `httpHandler` / `httpJsonHandler` | `lib/handlers/http.js` | API Gateway HTTP API v2; HTTP strategy maps errors to status codes |
+| `createHandler` | `lib/handlers/factory.js` | Central engine all factories delegate to (cache, container, config, scope, run) |
+
+### Strategies (`lib/strategies`)
+
+| Export | Behavior |
+| --- | --- |
+| `createEventStrategy` | Resolves and runs the processor once; resolves an optional `onError` |
+| `createParallelStrategy` | Validates the parsed event is an array; runs the processor on each record concurrently (`Promise.all`), each in its own child scope |
+| `createHttpStrategy` | Catches processor errors, boomifies them, logs a warning, returns `{ statusCode }` |
+
+### Wrappers (`lib/wrappers`)
+
+| Export | Role |
+| --- | --- |
+| `createInvokeWrapper` | Orchestrates parse → strategy → serialize with start/data/end logging |
+| `createRecordWrapper` | Per-record inner loop for the parallel strategy (own ctx/log per record) |
+
+### Parsers and serializers (`lib/parsers`, `lib/serializers`)
+
+- **Parsers:** `identityParser`, `sqsParser` / `sqsJsonParser`, `eventbridgeParser`,
+  `recordsParser`, `apiGatewayProxyParser` / `apiGatewayProxyJsonParser`. These normalize
+  raw events — typing SQS attributes (String / Number / Binary), unwrapping DLQ records,
+  and validating API Gateway v2 (`version` `2.0`) payloads.
+- **Serializers:** `identitySerializer`, `apiGatewayProxySerializer` /
+  `apiGatewayProxyJsonSerializer`. The JSON variant stringifies `body` and fills in
+  default HTTP response fields.
+
+### Utilities
+
+`createCtx` (`lib/ctx.js`), `getRequestId` (`lib/request-id.js`),
+`discoverEventType` (`lib/event/discover.js` — distinguishes `aws:sqs` from everything
+else), `createLogger` / `logFatal` (`lib/logger.js`), `createGetConfig` wrapping ace's
+`getConfig` (`lib/config.js`), `createScope` / `registerContext` (`lib/container.js`),
+`createCache` (`lib/cache.js`, 60s TTL), `readJson` (`lib/fs.js`), and `securityHeaders`
+(`lib/headers.js`).
+
+## Observability
+
+glhf is a published library, not a deployed service, so there is **no application AWS
+infrastructure to inspect** — no DynamoDB, SQS, SNS, Step Functions, EventBridge,
+AppSync, or CloudFront in this repo. The observability behavior below is what the library
+establishes for **consuming services**; find runtime logs in the consuming Lambda's own
+CloudWatch log groups (`/aws/lambda/<consumer-service>-<stage>-<function>`).
+
+- **Structured logs.** Every handler emits structured logs via
+  `@pureskillgg/mlabs-logger`. The factory seeds a child logger with env metadata and
+  AWS request context, derives a `reqId` (from SQS message attributes, `event.reqId`, or
+  a fresh uuid), and logs **start / data / end** around each processor run. Verbosity is
+  controlled by `LOG_LEVEL` (defaults to `info`); the consuming service also sets
+  `LOG_ENV`, `LOG_SYSTEM`, `LOG_SERVICE`, and `LOG_VERSION`. To trace a single
+  invocation, filter the consumer's log group by its `reqId`.
+- **Errors.** Synchronous invoke errors propagate to the caller. HTTP handlers convert
+  errors to status codes with `@hapi/boom` (`createHttpStrategy`). glhf itself wires no
+  DLQ or retry sink — those belong to the consuming service's Serverless config; the
+  `eventbridgeHandler` is what lets a service **redrive** its own EventBridge / `onFailure`
+  DLQ messages (see the deep-dive below).
+- **Sentry.** glhf does not bundle Sentry; consuming services typically wrap their handler
+  with `@sentry/serverless`. The example deploy in this repo demonstrates that pattern.
+
+### Example deployment (red/blue)
+
+The `serverless.yml` + `serverless/*.yml` + `handlers/` exist **only** as an
+integration test of the library, deployed under service `glhf` (default stage `stg`):
+
+- **`glhf-${sls:stage}-red`** (`handlers/red.handler`) — reads
+  `BLUE_LAMBDA_FUNCTION_SSM_PATH` via ace's `ssmString` and invokes the blue Lambda
+  through `@pureskillgg/awsjs` `LambdaClient`.
+- **`glhf-${sls:stage}-blue`** (`handlers/blue.handler`, env `RANK=ge`) — the downstream
+  target invoked by red.
+- **SSM parameter** `/pureskillgg/glhf/${stage}/glhf/blue_lambda_function`
+  (`AWS::SSM::Parameter`, type `String`, `Value: Ref BlueLambdaFunction` in
+  `serverless/resources.yml`) — holds the deployed blue function; red reads it and IAM
+  grants `ssm:GetParameter` on `/${owner}/${app}/${stage}/${name}/*`.
+- Example handlers are Sentry-wrapped (`Sentry.AWSLambda.wrapHandler`, with the
+  `SentryNodeServerlessSDK:40` Lambda layer) purely to exercise the consumer pattern.
+
+Log groups for the example deploy (30-day retention): `/aws/lambda/glhf-${sls:stage}-red`
+and `/aws/lambda/glhf-${sls:stage}-blue`.
+
+> Note: the `httpApi` block in `serverless.yml` has its default endpoint disabled and **no
+> function attaches an `httpApi` event**, so no API Gateway is actually provisioned for
+> the example.
+
+## Documentation
+
+- [Handler lifecycle and DI scoping](./docs/handler-lifecycle.md) — the cold-start →
+  per-invocation → per-record flow, the parent / per-event / per-record Awilix scope
+  model, and how EventBridge DLQ redrive unwrapping works. Start here if a consuming
+  service's dependencies or `reqId` are not what you expect.
+
 ## Development and Testing
 
 ### Quickstart
@@ -414,6 +569,8 @@ Portions of code in this project were taken and adapted from
 [@meltwater/jackalambda] which is licensed under the MIT license.
 
 [@meltwater/jackalambda]: https://github.com/meltwater/jackalambda
+[Boom]: https://hapi.dev/module/boom/
+[cache-manager]: https://www.npmjs.com/package/cache-manager
 
 ## Warranty
 

--- a/docs/handler-lifecycle.md
+++ b/docs/handler-lifecycle.md
@@ -1,0 +1,110 @@
+# Handler lifecycle and DI scoping
+
+This is a companion to the [README](../README.md) covering the single most
+intricate part of glhf: how every handler factory turns a raw AWS Lambda event
+into a processor call, and how the [Awilix] container is scoped along the way.
+All handler factories (`invokeHandler`, `eventbridgeHandler`, `sqsHandler`,
+`httpHandler`, …) delegate to the central `createHandler` factory in
+[`lib/handlers/factory.js`](../lib/handlers/factory.js); the differences between
+them are entirely in which **parser**, **serializer**, **wrapper**, and
+**strategy** they plug in.
+
+## Cold start vs per invocation
+
+**On cold start** (module load, once per container):
+
+1. A cache is created via `createCache` ([`lib/cache.js`](../lib/cache.js)) using
+   [cache-manager] with a **60-second TTL**.
+2. A root Awilix container is created.
+
+**On every invocation** `(event, context)`:
+
+1. **Build `ctx`** (`createCtx`, [`lib/ctx.js`](../lib/ctx.js)). This discovers the
+   event type and derives the request id:
+   - `discoverEventType` ([`lib/event/discover.js`](../lib/event/discover.js)) only
+     distinguishes two cases — an `aws:sqs` event (Symbol `sqs`) vs **everything
+     else** (Symbol `lambda`). That is the whole event taxonomy; the more specific
+     parsing happens in the per-handler parser.
+   - `getRequestId` ([`lib/request-id.js`](../lib/request-id.js)) derives `reqId`
+     from SQS message attributes, then `event.reqId`, and finally a fresh `uuid`.
+2. **Create a child logger** (`createLogger`, [`lib/logger.js`](../lib/logger.js))
+   seeded with env metadata (`LOG_ENV` / `LOG_SYSTEM` / `LOG_SERVICE` /
+   `LOG_VERSION`) and the AWS request context, at the `LOG_LEVEL` verbosity.
+3. **Load config** via `createGetConfig` ([`lib/config.js`](../lib/config.js)),
+   which wraps [AWS Config Executor]'s `getConfig` using the caller-supplied
+   `parameters` (SSM / env descriptors). The 60s cache means repeated warm
+   invocations do not re-fetch SSM on every call.
+4. **Register dependencies**: the caller's `registerDependencies(container, config)`
+   runs, then any test-time `overrideDependencies(container, config)` runs
+   immediately after (this is how AVA tests swap in fakes).
+5. **Create a scoped container** (`createScope` / `registerContext`,
+   [`lib/container.js`](../lib/container.js)) that registers the per-request
+   `reqId`, `log`, and the caller's `createProcessor` as the scoped `processor`.
+6. **Run the strategy through the wrapper**: the wrapper parses the event,
+   invokes the strategy (which resolves and calls `processor`), logs
+   **start / data / end**, and serializes the result.
+
+## Why the scoping matters
+
+There are up to three container layers, and getting them confused is the most
+common mistake when consuming glhf:
+
+- **Root container** — created once at cold start. Long-lived singletons that are
+  safe to reuse across invocations can live here, but `registerDependencies` runs
+  per invocation because it needs the freshly loaded `config`.
+- **Per-event scope** — created each invocation. `reqId`, `log`, and `processor`
+  are registered here so that anything resolved during this invocation sees the
+  correct request id and request-scoped logger.
+- **Per-record scope** — only for the **parallel** strategy (SQS, EventBridge).
+  `createParallelStrategy` ([`lib/strategies/parallel.js`](../lib/strategies/parallel.js))
+  asserts the parsed event is an array and then runs the processor on each record
+  **concurrently** via `Promise.all`. Each record gets its own child scope and its
+  own `ctx` / `log` through `createRecordWrapper`
+  ([`lib/wrappers/record.js`](../lib/wrappers/record.js)). So within a batch, each
+  message's processor sees a per-record logger — not one shared logger for the
+  whole batch.
+
+The single-run strategies are simpler:
+
+- `createEventStrategy` ([`lib/strategies/event.js`](../lib/strategies/event.js))
+  resolves and runs the processor once, resolving an optional `onError`.
+- `createHttpStrategy` ([`lib/strategies/http.js`](../lib/strategies/http.js))
+  catches processor errors, boomifies them with `@hapi/boom`, logs a warning, and
+  returns a `{ statusCode }` response (a thrown Boom error's status code is
+  respected).
+
+## EventBridge DLQ redrive unwrapping
+
+The `eventbridgeHandler` is what lets a consuming service redrive its own failed
+events, and the subtlety lives in `eventbridgeParser`
+([`lib/parsers/eventbridge.js`](../lib/parsers/eventbridge.js)). A message landing
+in a dead-letter queue can have **two different shapes** depending on who put it
+there:
+
+- **From EventBridge** (the event-rule DLQ, when EventBridge could not invoke the
+  function at all): the message body **is** the event record.
+- **From Lambda `onFailure`** (when EventBridge delivered the event but the async
+  invocation threw): the event record is nested inside the `requestPayload`
+  attribute of the invocation record.
+
+The parser normalizes both back into plain event records (unwrapping the SQS-DLQ
+`Records` via the SQS-JSON path and pulling out `requestPayload` when present), so
+the same processor can handle a live event and a redriven one identically. In a
+consuming service this is wired with a **disabled** (`enabled: false`) SQS trigger
+on the DLQ alongside the EventBridge trigger — see the README's EventBridge
+example — so the queue can be drained back through the same function on demand.
+
+## Where to look when something is wrong
+
+- **Unexpected `reqId`** → check the precedence in
+  [`lib/request-id.js`](../lib/request-id.js): SQS attributes win, then
+  `event.reqId`, then a generated uuid.
+- **A dependency is undefined inside the processor** → confirm it was registered
+  in `registerDependencies` (per-event), not assumed to be a cold-start singleton,
+  and that for parallel handlers it resolves correctly inside the per-record
+  child scope.
+- **Config looks stale** → remember the 60s cache TTL on warm containers.
+
+[Awilix]: https://github.com/jeffijoe/awilix
+[AWS Config Executor]: https://github.com/pureskillgg/ace
+[cache-manager]: https://www.npmjs.com/package/cache-manager


### PR DESCRIPTION
## What changed

Rewrites the thin top of `glhf`'s README and adds reference + observability sections, while preserving every existing boilerplate and handler-factory section verbatim.

### README
- **New lead**: one-line summary + a "What it does" section (the real handler-factory family: `invokeHandler`, `eventbridgeHandler`, `sqsHandler`/`sqsJsonHandler`, `httpHandler`/`httpJsonHandler`) + a "Pipeline role" section noting it is a shared library (`@pureskillgg/glhf`) consumed by `csgo-mutator`, `csgo-profile`, `oauthjs`, and other Node Lambdas, with no production infra of its own.
- **Building blocks** reference table listing the real confirmed exports (handler factories, strategies, wrappers, parsers, serializers, utilities) by source file.
- **Observability** section explaining that runtime logs live in the *consuming* service's CloudWatch log groups, the structured-logging / `reqId` / `LOG_LEVEL` conventions, Boom HTTP errors, and EventBridge DLQ redrive — plus a clearly-labelled "Example deployment (red/blue)" subsection covering the `glhf-${stage}-red`/`-blue` integration-test Lambdas, the `blue_lambda_function` SSM parameter, and the 30-day-retention log groups.
- **Documentation** section linking the new deep-dive.

### Preserved verbatim
All existing badges, the original invoke example, Installation, Usage, Handler Factories docs (Invoke / EventBridge / SQS / HTTP / Advanced usage), Development and Testing, Requirements, Publishing, Deployment, GitHub Actions secrets, Contributing, License, and Warranty.

### New deep-dive
- `docs/handler-lifecycle.md` — the cold-start → per-invocation → per-record flow, the parent/per-event/per-record Awilix scope model, and EventBridge DLQ redrive unwrapping (EventBridge body vs Lambda `requestPayload`).

### Corrections applied from verification
- `@pureskillgg/awsjs` is described as a **devDependency** used by the example handlers, not a runtime dependency.
- No invented ARNs; resources referenced by SSM-key/template name only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)