### PR TITLE
Remove Grafana annotation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,27 +78,6 @@ jobs:
         if: ${{ github.event.inputs.environment == 'staging' || github.event.client_payload.environment == 'staging' }}
         env:
           SERVERLESS_STAGE: stg
-      - name: Get commit message
-        id: message
-        run: |
-          {
-            echo "message<<EOF"
-            git log --format=%B -n 1 ${{ github.sha }}
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Grafana Annotation
-        uses: pureskillgg/psgg-grafana-annotation-action@v2.0.1
-        with:
-          grafanaHost: ${{ secrets.GRAFANA_API_ORIGIN }}
-          grafanaToken: ${{ secrets.GRAFANA_API_KEY }}
-          grafanaTags: |
-            deployment
-            ${{ github.event.repository.name }}
-            ${{ github.event.client_payload.environment }}${{ github.event.inputs.environment }}
-          grafanaText: >-
-            ${{ steps.message.outputs.message }}
-            ${{ github.event.client_payload.ref }}${{ github.event.inputs.ref }}
-            ${{ github.sha }}
       - name: Get version
         id: version
         run: |

--- a/README.md
+++ b/README.md
@@ -523,8 +523,6 @@ The following repository secrets must be set on [GitHub Actions]:
 - `AWS_ACCESS_KEY_ID`: AWS access key ID.
 - `AWS_SECRET_ACCESS_KEY`: AWS secret access key.
 - `GH_TOKEN`: A personal access token that can trigger workflows.
-- `GRAFANA_API_ORIGIN`: The Grafana origin to push annotations.
-- `GRAFANA_API_KEY`: The Grafana key key for pushing annotations.
 - `DISCORD_WEBHOOK`: The Discord webhook to notify on deploy.
 - `SENTRY_AUTH_TOKEN`: The Sentry auth token.
 


### PR DESCRIPTION
The `GRAFANA_API_ORIGIN` and `GRAFANA_API_KEY` org secrets have been removed — we no longer push deploy annotations to Grafana.

- Remove the **Grafana Annotation** step from the deploy/release workflow (and its now-dead "Get commit message" helper step, where present)
- Remove/update Grafana secret references and prose in README/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)