### PR TITLE
Upgrade toolchain to Node 22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="18"
+ARG VARIANT="22"
 
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "VARIANT": "18"
+      "VARIANT": "22"
     }
   },
   "extensions": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 4.0.0
+
+### Changed
+
+- **Breaking:** Require Node.js 22+ — `engines.node` is now `>=22.0.0`,
+  dropping support for Node versions below 22. Also bump the devcontainer to
+  Node 22. (CI already ran on Node 22.)
+
 ## 3.0.0 / 2026-06-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "report": "nyc report"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@hapi/boom": "^9.1.3",


### PR DESCRIPTION
Finishes the Node.js 22 alignment. glhf's CI already runs on Node 22 (green on master, including the `serverless package` build job); this brings the declared engine and devcontainer in line.

### Changes
- **`package.json` `engines.node` `>=20.0.0` → `>=22.0.0`** (breaking — drops Node <22)
- `.devcontainer` (devcontainer.json + Dockerfile) `VARIANT` `18` → `22`

`.nvmrc` was already `22`. The example `serverless.yml` (a v2 test fixture) keeps `nodejs18.x` — it isn't a deployed artifact and bumping the runtime would risk the Serverless v2 schema; it's left for a separate Serverless upgrade.

### Versioning
`engines` → `>=22` is breaking, so this is an incoming **major**. The `version` field is left for the version action; `CHANGELOG.md` reflects the incoming major (`4.0.0`). glhf uses yarn — `yarn.lock` is unaffected by the engines change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)